### PR TITLE
Support Ruby 3

### DIFF
--- a/lib/retriable_proxy.rb
+++ b/lib/retriable_proxy.rb
@@ -26,10 +26,8 @@ module RetriableProxy
     end
   
     # Forwards all methods not defined on the Wrapper to the wrapped object.
-    # Only supports ruby 3
-    def method_missing(*args, **kwargs, &block)
-      method_name = args[0]
-      __retrying(method_name) { @o.public_send(*args, **kwargs, &block) }
+    def method_missing(method_name, ...)
+      __retrying(method_name) { @o.public_send(method_name, ...) }
     end
   
     private

--- a/lib/retriable_proxy.rb
+++ b/lib/retriable_proxy.rb
@@ -26,13 +26,10 @@ module RetriableProxy
     end
   
     # Forwards all methods not defined on the Wrapper to the wrapped object.
-    def method_missing(*a)
-      method_name = a[0]
-      if block_given?
-        __retrying(method_name) { @o.public_send(*a){|*ba| yield(*ba)} }
-      else
-        __retrying(method_name) { @o.public_send(*a) }
-      end
+    # Only supports ruby 3
+    def method_missing(*args, **kwargs, &block)
+      method_name = args[0]
+      __retrying(method_name) { @o.public_send(*args, **kwargs, &block) }
     end
   
     private


### PR DESCRIPTION
Methods with keywords argument no longer work with RetriableProxy in Ruby 3.0 due to this change: [Separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

This change supports makes keyword arguments supported for Ruby 2.7 and up. I could potentially add support for Ruby 2.6, but it's going to be EOL soon.